### PR TITLE
Add provider block for helm in the blueprint

### DIFF
--- a/blueprints/getting-started/main.tf
+++ b/blueprints/getting-started/main.tf
@@ -72,6 +72,14 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
 }
+  
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
 
 locals {
   tenant      = "aws001"  # AWS account name or unique id for tenant


### PR DESCRIPTION
This resolves the following error...

```Error: Kubernetes cluster unreachable: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
│
│   with module.eks-blueprints-kubernetes-addons.module.ondat[0].module.helm_addon.helm_release.addon[0],
│   on .terraform/modules/eks-blueprints-kubernetes-addons.ondat.helm_addon/modules/kubernetes-addons/helm-addon/main.tf line 1, in resource "helm_release" "addon":
│    1: resource "helm_release" "addon" {
│
```

## Description

Please include:
- [ ] a summary of the change and which issue is fixed
- [ ] relevant motivation and context
- [ ] any dependencies that are required for this change

Fixes # (issue)

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe:
- the tests that you ran to verify your changes
- the instructions so we can reproduce
- the list any relevant details for your test configuration

**Test Configuration**:
* Kubernetes distribution
* Kubernetes version:
* How many control plane node:
* KMS:
* KMS version:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
