### PR TITLE
Upgrade AWS CLI

### DIFF
--- a/.github/workflows/e2e-terratest.yaml
+++ b/.github/workflows/e2e-terratest.yaml
@@ -26,6 +26,14 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Upgrade AWS CLI
+        run:  |
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            rm /tmp/awscliv2.zip
+            sudo /tmp/aws/install --update
+            rm -rf /tmp/aws/
+
       - name: Configure AWS credentials from Test account
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
## Description

Please include:
- [x] a summary of the change and which issue is fixed
- [x] relevant motivation and context
- [x] any dependencies that are required for this change

[Currently the AWS CLI version seems to be out of date as the `apiVersion` of Terraform-created clusters of the resource `client.authentication.k8s.io` is `v1alpha1` which is deprecated.](https://github.com/ondat/terraform-eksblueprints-ondat-addon/runs/7042941898?check_suite_focus=true#step:7:4565)

In order to resolve this, we'll upgrade `aws-cli` so we can get `v1beta1`.

Fixes # (issue)
N/A

## Type of change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe:
- the tests that you ran to verify your changes
- the instructions so we can reproduce
- the list any relevant details for your test configuration

**Test Configuration**:
* Kubernetes distribution
* Kubernetes version:
* How many control plane node:
* KMS:
* KMS version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
